### PR TITLE
[ch24144] Residual 'Unassociated to CP Output' after Partner user adds and then deletes a PD output

### DIFF
--- a/intervention-results/results-structure/results-structure.ts
+++ b/intervention-results/results-structure/results-structure.ts
@@ -478,7 +478,8 @@ export class ResultsStructure extends CommentsMixin(ContentPanelMixin(LitElement
 
   deletePDOutputFromPD(lower_result_id: number) {
     const endpoint = getEndpoint(interventionEndpoints.lowerResultsDelete, {
-      lower_result_id
+      lower_result_id,
+      intervention_id: this.interventionId
     });
     _sendRequest({
       method: 'DELETE',

--- a/utils/intervention-endpoints.ts
+++ b/utils/intervention-endpoints.ts
@@ -141,7 +141,7 @@ export const interventionEndpoints: EtoolsEndpoints = {
     template: '/api/comments/v1/partners/intervention/<%=interventionId%>/csv/'
   },
   lowerResultsDelete: {
-    template: '/api/pmp/v3/interventions/<%=interventionId%>/pd-outputs/<%=lower_result_id%>/'
+    template: '/api/pmp/v3/interventions/<%=intervention_id%>/pd-outputs/<%=lower_result_id%>/'
   },
   createIndicator: {
     template: '/api/pmp/v3/interventions/lower-results/<%=id%>/indicators/'


### PR DESCRIPTION
[ch24144] Residual 'Unassociated to CP Output' after Partner user adds and then deletes a PD output