### PR TITLE
[ch24573] ePD: When PD/SPD has been sent to Partner (or ACCEPTed by e…

### DIFF
--- a/intervention-timing/reporting-requirements/partner-reporting-requirements.ts
+++ b/intervention-timing/reporting-requirements/partner-reporting-requirements.ts
@@ -222,6 +222,7 @@ export class PartnerReportingRequirements extends connectStore(LitElement) {
                 name="special"
                 .interventionId="${this.interventionId}"
                 .requirementsCount="${this.specialRequirementsCount}"
+                .editMode="${!this.isReadonly}"
                 @count-changed=${(e: CustomEvent) => this.updateSRRCount(e.detail)}
               >
               </special-reporting-requirements>

--- a/intervention-timing/reporting-requirements/srr/special-reporting-requirements.ts
+++ b/intervention-timing/reporting-requirements/srr/special-reporting-requirements.ts
@@ -42,7 +42,7 @@ export class SpecialReportingRequirements extends ReportingRequirementsCommonMix
         ${translate('INTERVENTION_TIMING.PARTNER_REPORTING_REQUIREMENTS.NO_SPECIAL_REPORTING_REQUIREMENTS')}
       </div>
 
-      <div class="row-h">
+      <div class="row-h" ?hidden="${!this.editMode}">
         <paper-button class="secondary-btn" @click="${this._openAddDialog}"
           >${translate('INTERVENTION_TIMING.PARTNER_REPORTING_REQUIREMENTS.ADD_REQUIREMENTS')}</paper-button
         >
@@ -77,6 +77,9 @@ export class SpecialReportingRequirements extends ReportingRequirementsCommonMix
       </div>
     `;
   }
+
+  @property({type: Boolean})
+  editMode!: boolean;
 
   @property({type: Object})
   addEditDialog!: AddEditSpecialRepReqEl;


### PR DESCRIPTION
[ch24573] ePD: When PD/SPD has been sent to Partner (or ACCEPTed by either party), the Special Report "ADD REQUIREMENTS" is still available, and when UNICEF Focal Point tries to add a Special Report, error occurs.