### PR TITLE
[ch26937] [High] Adding input budget on activity pop-up extends the popup below the browser bottom and makes the save button inaccessible

### DIFF
--- a/common/components/activity/activity-items-table.ts
+++ b/common/components/activity/activity-items-table.ts
@@ -18,6 +18,7 @@ import {translate} from 'lit-translate';
 import {translatesMap} from '../../../utils/intervention-labels-map';
 import {sharedStyles} from '@unicef-polymer/etools-modules-common/dist/styles/shared-styles-lit';
 import {callClickOnSpacePushListener} from '@unicef-polymer/etools-modules-common/dist/utils/common-methods';
+import EtoolsDialog from '@unicef-polymer/etools-dialog/etools-dialog';
 
 @customElement('activity-items-table')
 export class ActivityItemsTable extends LitElement {
@@ -42,6 +43,7 @@ export class ActivityItemsTable extends LitElement {
 
   @property() activityItems: Partial<InterventionActivityItem>[] = [];
   @property() readonly: boolean | undefined = false;
+  @property() dialogElement!: EtoolsDialog;
   @property({type: String})
   currency = '';
 
@@ -68,7 +70,10 @@ export class ActivityItemsTable extends LitElement {
           html`<activity-item-row
             .activityItem="${item}"
             @item-changed="${({detail}: CustomEvent) => this.updateActivityItem(index, detail)}"
-            @remove-item="${() => this.updateActivityItem(index, null)}"
+            @remove-item="${() => {
+              this.updateActivityItem(index, null);
+              this.resizeDialog();
+            }}"
             .readonly="${this.readonly}"
             .lastItem="${this.isLastItem(index)}"
             .currency="${this.currency}"
@@ -95,7 +100,14 @@ export class ActivityItemsTable extends LitElement {
         name: ''
       }
     ];
+    this.resizeDialog();
     this.setFocusOnFirstActivity();
+  }
+
+  resizeDialog() {
+    if (this.dialogElement) {
+      this.dialogElement.notifyResize();
+    }
   }
 
   setFocusOnFirstActivity() {

--- a/intervention-workplan/effective-efficient-programme-mgmt/activity-dialog.ts
+++ b/intervention-workplan/effective-efficient-programme-mgmt/activity-dialog.ts
@@ -1,4 +1,4 @@
-import {LitElement, html, property, customElement} from 'lit-element';
+import {LitElement, html, property, customElement, query} from 'lit-element';
 import '@polymer/paper-input/paper-input';
 import '@polymer/paper-input/paper-textarea';
 import '@unicef-polymer/etools-currency-amount-input';
@@ -18,6 +18,7 @@ import {formatCurrency, getTotal} from '../../common/components/activity/get-tot
 import {cloneDeep} from '@unicef-polymer/etools-modules-common/dist/utils/utils';
 import {AnyObject, ManagementBudgetItem} from '@unicef-polymer/etools-types';
 import {ActivityItemsTable} from '../../common/components/activity/activity-items-table';
+import EtoolsDialog from '@unicef-polymer/etools-dialog/etools-dialog';
 
 /**
  * @customElement
@@ -163,6 +164,7 @@ export class ActivityDialog extends ComponentBaseMixin(LitElement) {
           </paper-toggle-button>
         </div>
         <activity-items-table
+          .dialogElement=${this.dialogElement}
           ?hidden="${!this.useInputLevel}"
           .activityItems="${this.items || []}"
           .currency="${this.currency}"
@@ -199,6 +201,7 @@ export class ActivityDialog extends ComponentBaseMixin(LitElement) {
   @property() useInputLevel = false;
   @property({type: String}) currency = '';
   @property({type: Array}) items: ManagementBudgetItem[] = [];
+  @query('etools-dialog') private dialogElement!: EtoolsDialog;
 
   onSaveClick() {
     const activityItemsValidationSummary = this.validateActivityItems();

--- a/intervention-workplan/results-structure/modals/activity-dialog/activity-data-dialog.ts
+++ b/intervention-workplan/results-structure/modals/activity-dialog/activity-data-dialog.ts
@@ -1,4 +1,4 @@
-import {CSSResultArray, customElement, html, LitElement, property, TemplateResult} from 'lit-element';
+import {CSSResultArray, customElement, html, LitElement, property, TemplateResult, query} from 'lit-element';
 import '@unicef-polymer/etools-currency-amount-input';
 import '@polymer/paper-input/paper-textarea';
 import '@polymer/paper-toggle-button';
@@ -23,6 +23,7 @@ import {gridLayoutStylesLit} from '@unicef-polymer/etools-modules-common/dist/st
 import {getEndpoint} from '@unicef-polymer/etools-modules-common/dist/utils/endpoint-helper';
 import {validateRequiredFields} from '@unicef-polymer/etools-modules-common/dist/utils/validation-helper';
 import {getDifference} from '@unicef-polymer/etools-modules-common/dist/mixins/objects-diff';
+import EtoolsDialog from '@unicef-polymer/etools-dialog/etools-dialog.js';
 
 @customElement('activity-data-dialog')
 export class ActivityDataDialog extends DataMixin()<InterventionActivity>(LitElement) {
@@ -38,6 +39,7 @@ export class ActivityDataDialog extends DataMixin()<InterventionActivity>(LitEle
   @property() useInputLevel = false;
   @property({type: String}) spinnerText = 'Loading...';
   @property() readonly: boolean | undefined = false;
+  @query('etools-dialog') private dialogElement!: EtoolsDialog;
   quarters: ActivityTimeFrames[] = [];
 
   set dialogData({activityId, pdOutputId, interventionId, quarters, readonly, currency}: any) {
@@ -218,6 +220,7 @@ export class ActivityDataDialog extends DataMixin()<InterventionActivity>(LitEle
             ${translate('USE_INPUT_LEVEL')}
           </paper-toggle-button>
           <activity-items-table
+            .dialogElement=${this.dialogElement}
             ?hidden="${!this.useInputLevel}"
             .activityItems="${this.editedData.items || []}"
             .readonly="${this.readonly}"


### PR DESCRIPTION
[ch26937] [High] Adding input budget on activity pop-up extends the popup below the browser bottom and makes the save button inaccessible
