### PR TITLE
[ch26909] "Add CP Output" tooltip color change

### DIFF
--- a/intervention-workplan/results-structure/results-structure.ts
+++ b/intervention-workplan/results-structure/results-structure.ts
@@ -208,6 +208,7 @@ export class ResultsStructure extends CommentsMixin(ContentPanelMixin(LitElement
         :host {
           display: block;
           margin-bottom: 24px;
+          --paper-tooltip-background: #818181;
         }
 
         etools-data-table-row::part(edt-list-row-wrapper) {


### PR DESCRIPTION
[ch26909] Add tooltip on "Add CP Output" plus button on the results card. The tooltip should say "Add CP Output" similar to supply upload