### PR TITLE
[ch28167] Fund reservation related tooltip showing up again when there is no Fund reservation (regression issue)

### DIFF
--- a/intervention-workplan/budget-summary/budget-summary.ts
+++ b/intervention-workplan/budget-summary/budget-summary.ts
@@ -201,6 +201,10 @@ export class BudgetSummaryEl extends CommentsMixin(FrNumbersConsistencyMixin(Lit
   }
 
   currenciesMatch() {
+    if (!this.frsDetails.frs.length) {
+      // if no FR number added, hide currency-mismatch tooltip
+      return true;
+    }
     return this.allCurrenciesMatch(this.frsDetails.currencies_match, this.frsDetails.frs, this.budgetSummary.currency);
   }
 }


### PR DESCRIPTION
[ch28167] Fund reservation related tooltip showing up again when there is no Fund reservation (regression issue)