### PR TITLE
[ch29467] Results Structure - hover style present for CP Programme Output when section is readonly

### DIFF
--- a/intervention-workplan/results-structure/cp-output-level.ts
+++ b/intervention-workplan/results-structure/cp-output-level.ts
@@ -77,15 +77,13 @@ export class CpOutputLevel extends LitElement {
                             )}
                           </div>
                         </div>
-                        <div class="hover-block">
+                        <div class="hover-block" ?hidden="${this.readonly}">
                           <paper-icon-button
                             icon="icons:create"
-                            ?hidden="${this.readonly}"
                             @click="${this.openEditCpOutputPopup}"
                           ></paper-icon-button>
                           <paper-icon-button
                             icon="icons:delete"
-                            ?hidden="${this.readonly}"
                             @click="${this.openDeleteCPOutputPopup}"
                           ></paper-icon-button>
                         </div>


### PR DESCRIPTION
[ch29467] Results Structure - hover style present for CP Programme Output when section is readonly