### PR TITLE
[ch29557] Comment mode: Time stamp too close to name

### DIFF
--- a/common/components/comments/comment.styles.ts
+++ b/common/components/comments/comment.styles.ts
@@ -49,6 +49,11 @@ export const CommentStyles: CSSResult = css`
     font-size: 16px;
     line-height: 24px;
     color: var(--primary-text-color);
+    padding-right: 6px;
+  }
+  :host([my-comment]) .name {
+    padding-right: 0px;
+    padding-left: 6px;
   }
   .date {
     font-size: 12px;


### PR DESCRIPTION
[ch29557] Comment mode: Time stamp too close to name