### PR TITLE
[ch29563] [Results Structure-Standard view]: Cancel hover functionality when in comment mode on PD Output description

### DIFF
--- a/intervention-workplan/results-structure/results-structure.ts
+++ b/intervention-workplan/results-structure/results-structure.ts
@@ -208,7 +208,10 @@ export class ResultsStructure extends CommentsMixin(ContentPanelMixin(LitElement
                         </div>
                       </div>
 
-                      <div class="hover-block" ?hidden="${!this.permissions.edit.result_links}">
+                      <div
+                        class="hover-block"
+                        ?hidden="${!this.permissions.edit.result_links || this.commentsModeEnabledFlag}"
+                      >
                         <paper-icon-button
                           icon="icons:create"
                           @click="${() => this.openPdOutputDialog(pdOutput, result.cp_output)}"


### PR DESCRIPTION
[ch29563] [Results Structure-Standard view]: Cancel hover functionality when in comment mode on PD Output description