### PR TITLE
[ch29592] Geographical Coverage: Location drop-down jumps to right/left while selecting/deselecting locations from the list

### DIFF
--- a/intervention-strategy/geographical-coverage/geographical-coverage.ts
+++ b/intervention-strategy/geographical-coverage/geographical-coverage.ts
@@ -147,6 +147,7 @@ export class GeographicalCoverage extends CommentsMixin(ComponentBaseMixin(LitEl
             option-value="id"
             error-message=${translate('LOCATIONS_ERR')}
             trigger-value-change-event
+            horizontal-align="left"
             @etools-selected-items-changed="${({detail}: CustomEvent) =>
               this.selectedItemsChanged(detail, 'flat_locations')}"
           >


### PR DESCRIPTION
[ch29592] Geographical Coverage: Location drop-down jumps to right/left while selecting/deselecting locations from the list