### PR TITLE
[ch31350] Results Structure: Remove redundant 'Indicator'/'Activity Name' labels in standard view, Development status

### DIFF
--- a/intervention-workplan/results-structure/pd-activities.ts
+++ b/intervention-workplan/results-structure/pd-activities.ts
@@ -12,6 +12,7 @@ import {sendRequest} from '@unicef-polymer/etools-ajax';
 import {getStore} from '@unicef-polymer/etools-modules-common/dist/utils/redux-store-access';
 import {getIntervention} from '../../common/actions/interventions';
 import {fireEvent} from '@unicef-polymer/etools-modules-common/dist/utils/fire-custom-event';
+import {isEmptyObject} from '@unicef-polymer/etools-modules-common/dist/utils/utils';
 import {formatServerErrorAsText} from '@unicef-polymer/etools-ajax/ajax-error-parser';
 import {interventionEndpoints} from '../../utils/intervention-endpoints';
 import {getEndpoint} from '@unicef-polymer/etools-modules-common/dist/utils/endpoint-helper';
@@ -59,7 +60,10 @@ export class PdActivities extends CommentsMixin(TruncateMixin(LitElement)) {
           </etools-info-tooltip>
         </div>
         <div slot="row-data-details">
-          <div class="table-row table-head align-items-center" ?hidden="${this.readonly}">
+          <div
+            class="table-row table-head align-items-center"
+            ?hidden="${this.readonly || isEmptyObject(this.activities)}"
+          >
             <div class="flex-1 left-align layout-vertical">${translate('ACTIVITY_NAME')}</div>
             <div class="flex-1 secondary-cell center">${translate('TIME_PERIODS')}</div>
             <div class="flex-1 secondary-cell right">${translate('PARTNER_CASH')}</div>
@@ -151,19 +155,7 @@ export class PdActivities extends CommentsMixin(TruncateMixin(LitElement)) {
                   </div>
                 `
               )
-            : html`
-                <div class="table-row empty align-items-center">
-                  ${this.readonly
-                    ? translate('THERE_ARE_NO_PD_ACTIVITIES')
-                    : html`
-                        <div class="flex-1 left-align layout-vertical">-</div>
-                        <div class="flex-1 secondary-cell center">-</div>
-                        <div class="flex-1 secondary-cell right">-</div>
-                        <div class="flex-1 secondary-cell right">-</div>
-                        <div class="flex-1 secondary-cell right">-</div>
-                      `}
-                </div>
-              `}
+            : html` <div class="table-row empty center-align">${translate('THERE_ARE_NO_PD_ACTIVITIES')}</div> `}
         </div>
       </etools-data-table-row>
     `;

--- a/intervention-workplan/results-structure/pd-indicators.ts
+++ b/intervention-workplan/results-structure/pd-indicators.ts
@@ -16,7 +16,7 @@ import {getStore} from '@unicef-polymer/etools-modules-common/dist/utils/redux-s
 import {RootState} from '../../common/types/store.types';
 import './modals/indicator-dialog/indicator-dialog';
 import get from 'lodash-es/get';
-import {filterByIds, isJsonStrMatch} from '@unicef-polymer/etools-modules-common/dist/utils/utils';
+import {filterByIds, isEmptyObject, isJsonStrMatch} from '@unicef-polymer/etools-modules-common/dist/utils/utils';
 import EnvironmentFlagsMixin from '@unicef-polymer/etools-modules-common/dist/mixins/environment-flags-mixin';
 import cloneDeep from 'lodash-es/cloneDeep';
 import '@unicef-polymer/etools-modules-common/dist/layout/are-you-sure';
@@ -96,7 +96,10 @@ export class PdIndicators extends connectStore(EnvironmentFlagsMixin(LitElement)
           ></info-icon-tooltip>
         </div>
         <div slot="row-data-details">
-          <div class="table-row table-head align-items-center" ?hidden="${this.readonly}">
+          <div
+            class="table-row table-head align-items-center"
+            ?hidden="${this.readonly || isEmptyObject(this.indicators)}"
+          >
             <div class="flex-1 left-align">${translate('INDICATOR')}</div>
             <div class="flex-1 secondary-cell right">${translate('BASELINE')}</div>
             <div class="flex-1 secondary-cell right">${translate('TARGET')}</div>
@@ -122,18 +125,7 @@ export class PdIndicators extends connectStore(EnvironmentFlagsMixin(LitElement)
                   ></pd-indicator>
                 `
               )
-            : html`
-                <div class="table-row empty align-items-center">
-                  ${this.readonly
-                    ? translate('THERE_ARE_NO_PD_INDICATORS')
-                    : html`
-                        <div class="flex-1 left-align">-</div>
-                        <div class="flex-1 secondary-cell center">-</div>
-                        <div class="flex-1 secondary-cell right">-</div>
-                        <div class="flex-1 secondary-cell right">-</div>
-                      `}
-                </div>
-              `}
+            : html` <div class="table-row empty center-align">${translate('THERE_ARE_NO_PD_INDICATORS')}</div> `}
         </div>
       </etools-data-table-row>
     `;
@@ -327,11 +319,9 @@ export class PdIndicators extends connectStore(EnvironmentFlagsMixin(LitElement)
           display: block;
           background: var(--main-background);
         }
-        .table-row {
-          padding-right: 10% !important;
-        }
         .table-row:not(.empty) {
           min-height: 42px;
+          padding-right: 10% !important;
         }
         etools-data-table-row::part(edt-list-row-collapse-wrapper) {
           border-bottom: none;


### PR DESCRIPTION
[ch31350] Results Structure: Remove redundant 'Indicator'/'Activity Name' labels in standard view, Development status