### PR TITLE
[ch32275] Editor: Comment mode borders not disabled when the toggle is off

### DIFF
--- a/common/components/comments/comments-mixin.ts
+++ b/common/components/comments/comments-mixin.ts
@@ -92,7 +92,6 @@ export function CommentsMixin<T extends Constructor<LitElement>>(baseClass: T) {
 
     async setCommentMode() {
       await this.updateComplete;
-
       if (this.commentsModeEnabled) {
         this.startCommentMode();
       } else {
@@ -135,7 +134,8 @@ export function CommentsMixin<T extends Constructor<LitElement>>(baseClass: T) {
     private createMataData(element: HTMLElement, relatedTo: string, relatedToDescription: string): MetaData {
       const oldStyles: string = element.style.cssText;
       const counter: HTMLElement = this.createCounter();
-      const overlay: HTMLElement = this.createOverlay(relatedTo);
+      // prevent creating multiple overlays for the element
+      const overlay: HTMLElement = element.querySelector('.commentsOverlay') || this.createOverlay(relatedTo);
       element.append(overlay);
       return {
         element,
@@ -169,9 +169,10 @@ export function CommentsMixin<T extends Constructor<LitElement>>(baseClass: T) {
     }
 
     private createOverlay(relatedTo: string): HTMLElement {
+
       const comments: InterventionComment[] = this.comments[relatedTo] || [];
       const borderColor = comments.length ? '#FF4545' : '#81D763';
-      const element: HTMLElement = document.createElement('div');
+      const element: HTMLElement = Object.assign(document.createElement('div'), {className: 'commentsOverlay'});
       element.style.cssText = `
         position: absolute;
         top: 0;


### PR DESCRIPTION
[ch32275] Editor: Comment mode borders not disabled when the toggle is off