### PR TITLE
Revert "[ch31952] The Search section of the dropdown is covered by the header"

### DIFF
--- a/common/layout/page-content-header/intervention-page-content-header.ts
+++ b/common/layout/page-content-header/intervention-page-content-header.ts
@@ -17,7 +17,7 @@ export class InterventionPageContentHeader extends LitElement {
         :host {
           position: sticky;
           top: 0;
-          z-index: 200;
+          z-index: 121;
           width: 100%;
           box-sizing: border-box;
 


### PR DESCRIPTION
Revert "[ch31952] The Search section of the dropdown is covered by the header"